### PR TITLE
1.0.3

### DIFF
--- a/filters/__init__.py
+++ b/filters/__init__.py
@@ -17,4 +17,4 @@ from .complex import *
 from .string import *
 
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/filters/test.py
+++ b/filters/test.py
@@ -126,7 +126,12 @@ class BaseFilterTestCase(TestCase):
                 ),
             )
 
-        if expected_value is not self.skip_value_check:
+        check_value = (
+                (self.skip_value_check is not True)
+            and (expected_value is not self.skip_value_check)
+        )
+
+        if check_value:
             self._check_filter_value(
                 runner.cleaned_data,
                 runner.data

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url         = 'https://github.com/eflglobal/filters/',
 
     # Don't forget to update version number in `filters/__init__.py`!
-    version = '1.0.2',
+    version = '1.0.3',
 
     packages = ['filters'],
 


### PR DESCRIPTION
- `skip_value_check` can now be specified as a class-level attribute in test cases if you want to disable filtered value comparisons across all tests in that test case.
    - Previously, `skip_value_check` had to be included in *every* call to `assertFilterPasses` and `assertFilterErrors.
    - To use this feature, set `skip_value_check=True` in the test case definition.  E.g.:
        ```
        class SomeTestCase(TestCase):
            skip_value_check = True
        ```