### PR TITLE
1.2.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,6 @@ pipelines.
 
 Examples
 ========
-
 Validate a latitude position and round to manageable precision:
 
 .. code:: python
@@ -91,9 +90,14 @@ Install the latest stable version via pip::
 
     pip install filters
 
-Install the latest development version::
+Extensions
+==========
+The following extensions are available:
 
-    pip install https://github.com/eflglobal/filters/archive/develop.zip
+- `ISO Filters`_: Adds filters for interpreting standard codes and identifiers.
+  To install::
 
+     pip install filters[iso]
 
+.. _ISO Filters: https://pypi.python.org/pypi/filters-iso
 .. _Unicode normalization: https://en.wikipedia.org/wiki/Unicode_equivalence

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -1,0 +1,126 @@
+===============================
+Extending the Filters Namespace
+===============================
+Once you've :doc:`written your own filters </writing_filters>`, you can start using
+them right away!
+
+.. code:: python
+
+   In [1]: from filters_iso import Currency
+
+   In [2]: Currency().apply('pen')
+   Out[2]: PEN
+
+   In [3]: Currency().apply('foo')
+   FilterError: This is not a valid ISO 4217 currency code.
+
+Depending on your situation (and preferences), you might not mind importing
+your custom filters explicitly.
+
+However, sometimes all those imports start to get unwieldy, especially if you
+have to use namespaces in order to keep them all straight:
+
+.. code:: python
+
+   import filters as f
+   import filters_iso as iso_filters
+   import api.filters as api_filters
+
+   request_filter =\
+     f.FilterMapper({
+       'locale': f.Unicode | f.Strip | iso_filters.Locale,
+       'username': f.Unicode | f.Strip | api_filters.User | f.Required,
+     })
+
+And so on.  Some developers don't mind this; others can't stand it.
+
+For those of you who fall into the latter group, the Filters library provides an
+extensions framework that allows you to add your filters to the (nearly)
+top-level ``filters.ext`` namespace:
+
+.. code:: python
+
+   import filters as f
+
+   request_filter =\
+     f.FilterMapper({
+       'locale': f.Unicode | f.Strip | f.ext.Locale,
+       'username': f.Unicode | f.Strip | f.ext.User | f.Required,
+     })
+
+Note in the above example that the ``Locale`` and ``User`` filters do not need
+to be imported explicitly, and they are added automatically to the ``f.ext``
+namespace.
+
+Trade-Offs
+==========
+There is one downside to using the Extensions framework: IDE autocompletion
+won't work.
+
+Extension filters are registered at runtime, so your IDE's static analysis has
+no way to know what's available in ``filters.ext``.
+
+Depending on your IDE, however, there may be ways to work around this.  For
+example, `PyCharm's debugger can be configured to collect type information at
+runtime <https://blog.jetbrains.com/pycharm/2013/02/dynamic-runtime-type-inference-in-pycharm-2-7/>`_.
+
+Prerequisites
+=============
+In order to register your filters with the Extensions framework, your project
+must use `setuptools <https://setuptools.readthedocs.io/en/latest/>`_ and have
+a valid ``setup.py`` file.
+
+Registering Your Filters
+========================
+To add custom filters to the ``filters.ext`` namespace, register them as entry
+points using the ``filters.extensions`` key.
+
+Here's an example:
+
+.. code:: python
+
+   from setuptools import setup
+
+   setup(
+     ...
+     entry_points = {
+       'filters.extensions': [
+         # Load all filters from a single module.
+         'iso = filters_iso',
+
+         # Load a single class.
+         'currency = filters_iso:Currency',
+       ],
+     },
+   )
+
+Note in the example above that you can register as many filters as you want, and
+you can provide entire modules and/or individual classes.
+
+The name that you assign to each entry point is currently ignored.  The
+following configuration has the same effect as the previous one:
+
+.. code:: python
+
+   setup(
+     ...
+     entry_points = {
+       'filters.extensions': [
+         'foobie = filters_iso',
+         'bletch = filters_iso:Currency',
+       ],
+     },
+   )
+
+This may be used in the future to help resolve conflicts (see below), so we
+recommend that you choose a meaningful name for each entry point anyway.
+
+---------
+Conflicts
+---------
+In the event that two filters are registered with the same name, one of them
+will replace the other.  The order that entry points are processed is not
+defined, so it is not predictable which filter will "win".
+
+Future versions of the Filters library may provide more elegant ways to resolve
+these conflicts.

--- a/docs/filters_list.rst
+++ b/docs/filters_list.rst
@@ -43,21 +43,6 @@ string filters only accept unicode strings, unless otherwise noted.
    Note that the comparison is case sensitive; chain this filter with
    :py:class:`filters.CaseFold` for case-insensitive comparison.
 
-:py:class:`filters.Country`
-   Interprets the incoming value as an
-   `ISO 3166-1 alpha-2 or alpha-3 <https://en.wikipedia.org/wiki/ISO_3166-1>`_
-   country code.
-
-   The resulting value is a :py:class:`iso3166.Country` object (provided by the
-   `iso3166 <https://pypi.python.org/pypi/iso3166>`_ library).
-
-:py:class:`filters.Currency`
-   Interprets the incoming value as an
-   `ISO 4217 <https://en.wikipedia.org/wiki/ISO_4217>`_ currency code.
-
-   The resulting value is a :py:class:`moneyed.Currency` object (provided by
-   the `py-moneyed <https://pypi.python.org/pypi/py-moneyed>`_ library).
-
 :py:class:`filters.Date`
    Interprets a string as a date.  The result is a ``datetime.date`` instance.
 
@@ -85,15 +70,6 @@ string filters only accept unicode strings, unless otherwise noted.
    Note that this filter can be chained with other filters.  For example, you
    can use ``f.JsonDecode | f.FilterMapper(...)`` to apply filters to a JSON-
    encoded dict.
-
-:py:class:`filters.Locale`
-   Interprets the incoming value as an
-   `IETF Language Tag <https://en.wikipedia.org/wiki/IETF_language_tag>`_
-   (also known as BCP 47).
-
-   The resulting value is a :py:class:`language_tags.Tag.Tag` object (provided
-   by the `language_tags <https://pypi.python.org/pypi/language-tags>`_
-   library).
 
 :py:class:`filters.MaxBytes`
    Truncates a string to a max number of bytes, with support for multibyte
@@ -314,3 +290,53 @@ These filters are covered in more detail in :doc:`/complex_filters`.
 
    ``FilterRepeater`` can also process mappings (e.g., ``dict``); it will apply
    the filters to every value in the mapping, preserving the keys.
+
+----------
+Extensions
+----------
+The following filters are provided by the
+:doc:`Extensions framework </extensions>`.
+
+Note that extension filters are located in a different namespace; use
+``filters.ext`` to use them instead of ``filters``.  For example:
+
+.. code:: python
+
+   import filters as f
+
+   # Standard filter
+   f.Unicode().apply('foo')
+
+   # Extension filter - note `f.ext`.
+   f.ext.Country().apply('pe')
+
+ISO Filters
+-----------
+Adds filters for interpreting standard codes and identifiers.  To install this
+extension::
+
+   pip install filters[iso]
+
+:py:class:`filters.ext.Country`
+   Interprets the incoming value as an
+   `ISO 3166-1 alpha-2 or alpha-3 <https://en.wikipedia.org/wiki/ISO_3166-1>`_
+   country code.
+
+   The resulting value is a :py:class:`iso3166.Country` object (provided by the
+   `iso3166 <https://pypi.python.org/pypi/iso3166>`_ library).
+
+:py:class:`filters.ext.Currency`
+   Interprets the incoming value as an
+   `ISO 4217 <https://en.wikipedia.org/wiki/ISO_4217>`_ currency code.
+
+   The resulting value is a :py:class:`moneyed.Currency` object (provided by
+   the `py-moneyed <https://pypi.python.org/pypi/py-moneyed>`_ library).
+
+:py:class:`filters.ext.Locale`
+   Interprets the incoming value as an
+   `IETF Language Tag <https://en.wikipedia.org/wiki/IETF_language_tag>`_
+   (also known as BCP 47).
+
+   The resulting value is a :py:class:`language_tags.Tag.Tag` object (provided
+   by the `language_tags <https://pypi.python.org/pypi/language-tags>`_
+   library).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,5 +101,6 @@ Contents
    complex_filters
    List of Filters <filters_list>
    writing_filters
+   extensions
 
 .. _Unicode normalization: https://en.wikipedia.org/wiki/Unicode_equivalence

--- a/docs/writing_filters.rst
+++ b/docs/writing_filters.rst
@@ -179,3 +179,15 @@ Here's a starter test case for ``Pkcs7Pad``:
          u'Hello, world!',
          [Pkcs7Pad.CODE_INVALID_TYPE],
        )
+
+
+===================================
+Registering Your Filters (Optional)
+===================================
+Once you've packaged up your filters, you can register them with the Extensions
+framework to add them to the (nearly) top-level ``filters.ext`` namespace.
+
+This is an optional step; it may make your filters easier to use, though there
+are some trade-offs.
+
+See `Extensions Framework </extensions>`_ for more information.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     description = 'Validation and data pipelines made easy!',
     url         = 'https://filters.readthedocs.io/',
 
-    version = '1.2.0',
+    version = '1.2.1',
 
     packages = ['filters'],
 
@@ -53,10 +53,9 @@ setup(
 
     install_requires = dependencies,
 
-    # Coming soon!
-    # extras_require = {
-    #     'iso': ['filters-iso'],
-    # },
+    extras_require = {
+        'iso': ['filters-iso'],
+    },
 
     test_suite    = 'test',
     test_loader   = 'nose.loader:TestLoader',


### PR DESCRIPTION
# Filters v1.2.1
* ISO Filters can now be installed via the `iso` extra (`pip install filters[iso]`).
* Added documentation for the Extensions framework.