### PR TITLE
Release/1.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ python:
   - '2.7'
   - '3.5'
   - '3.6'
-install:
-  - pip install --upgrade pip
-  - pip install .
+install: pip install .
 script: python setup.py test
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - '2.7'
@@ -9,7 +10,7 @@ deploy:
   on:
     branch: master
   provider: pypi
-  distributions: "sdist bdist_wheel"
+  distributions: "bdist_wheel sdist"
   user: efl_phx
   password:
     secure: NIIkixHOpanll4TAjcjXAH3CiChZRnXrRd4uRHEAlcJbYnOve4WI7Diu0VZiAj8AHnhyy4P0dM56BMoqG6YtZiNrwJgeKiGWTYr4q1CEGdi421Mj7rLl+dAkL420IALLiCaGyhDbHctLwZYag6l/R8FIVMnT1PqWRGYmsWcJOmnh4HNeLBa0oQ2ICW2HOM3mOnHCE7qvvsKDnUDpAejNig4n7Xelx17nLCzjJdVWqCqEh21ZhSYmV/lHvBicS9TVzGso0vrzVEC8hHjRwMXrxDb391l/XH0BlOxDXwxuSfRoZRWrjRwvLbYj4Zntv+qr1uyqB41JF5mEBN6V7i8tBcJx4JfEiVLk9oyRM+N9pUOYOc23BIJsxxJDJoWUO8/XObyp6Uz+bQ0h9FuA/L0fQOKbZbfR8u2Erw08VjvGWJ+/oT3UQKz6vOzTCQtnV5VEmSmE1K2Owb/kvG9q+CFCNACmiJ83WuRB08VExEFTlpWw0LQpEwUXwANJhEx0bLrTFAmc7pgb++dpFrl6llQr9hVUipnEd/A+7aLbVkuwJqr4b6LPT4I9kFxOKRdUbeb3RupyjwVuf720cLz2o+Rx6ER5Nss8J+VqfhsTbspUUNUvByun2flZxv3MYqqKE+71MIu/aBD0LNMMezxAl6T6UQD8SXHhiXZvyKpOptTXT6M=

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ python:
 install: pip install .
 script: python setup.py test
 deploy:
-  on:
+- on:
     branch: master
+    python: '3.6'
   provider: pypi
-  distributions: "bdist_wheel sdist"
+  distributions: 'bdist_wheel sdist'
   user: efl_phx
   password:
     secure: NIIkixHOpanll4TAjcjXAH3CiChZRnXrRd4uRHEAlcJbYnOve4WI7Diu0VZiAj8AHnhyy4P0dM56BMoqG6YtZiNrwJgeKiGWTYr4q1CEGdi421Mj7rLl+dAkL420IALLiCaGyhDbHctLwZYag6l/R8FIVMnT1PqWRGYmsWcJOmnh4HNeLBa0oQ2ICW2HOM3mOnHCE7qvvsKDnUDpAejNig4n7Xelx17nLCzjJdVWqCqEh21ZhSYmV/lHvBicS9TVzGso0vrzVEC8hHjRwMXrxDb391l/XH0BlOxDXwxuSfRoZRWrjRwvLbYj4Zntv+qr1uyqB41JF5mEBN6V7i8tBcJx4JfEiVLk9oyRM+N9pUOYOc23BIJsxxJDJoWUO8/XObyp6Uz+bQ0h9FuA/L0fQOKbZbfR8u2Erw08VjvGWJ+/oT3UQKz6vOzTCQtnV5VEmSmE1K2Owb/kvG9q+CFCNACmiJ83WuRB08VExEFTlpWw0LQpEwUXwANJhEx0bLrTFAmc7pgb++dpFrl6llQr9hVUipnEd/A+7aLbVkuwJqr4b6LPT4I9kFxOKRdUbeb3RupyjwVuf720cLz2o+Rx6ER5Nss8J+VqfhsTbspUUNUvByun2flZxv3MYqqKE+71MIu/aBD0LNMMezxAl6T6UQD8SXHhiXZvyKpOptTXT6M=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
   - '2.7'
   - '3.5'
   - '3.6'
-install: pip install .
+install:
+  - pip install --upgrade pip
+  - pip install .
 script: python setup.py test
 deploy:
   on:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'class-registry',
         'python-dateutil',
         'pytz',
-        'py2casefold; python_version < "3.0"'
+        'py2casefold; python_version < "3.0"',
         'regex',
         'six',
         'typing; python_version < "3.0"',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     description = 'Validation and data pipelines made easy!',
     url         = 'https://filters.readthedocs.io/',
 
-    version = '1.3.0',
+    version = '1.3.1',
 
     packages = ['filters'],
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function
 
 from codecs import StreamReader, open
 from os.path import dirname, join, realpath
-from sys import version_info
 
 from setuptools import setup
 
@@ -18,28 +17,8 @@ with open(join(cwd, 'README.rst'), 'r', 'utf-8') as f: # type: StreamReader
 
 
 ##
-# For compatibility with versions of pip < 9, we will determine
-# dependencies at runtime.
-# Maybe once Travis upgrades their containers to use a newer version,
-# we'll switch to the newer syntax (:
-dependencies = [
-    'class-registry',
-    'python-dateutil',
-    'pytz',
-    'regex',
-    'six',
-]
-
-if version_info[0] < 3:
-    # noinspection SpellCheckingInspection
-    dependencies.extend([
-        'py2casefold', # 'py2casefold; python_version < "3.0"',
-        'typing', # 'typing; python_version < "3.0"',
-    ])
-
-
-##
 # Off we go!
+# noinspection SpellCheckingInspection
 setup(
     name        = 'filters',
     description = 'Validation and data pipelines made easy!',
@@ -51,7 +30,15 @@ setup(
 
     long_description = long_description,
 
-    install_requires = dependencies,
+    install_requires = [
+        'class-registry',
+        'python-dateutil',
+        'pytz',
+        'py2casefold; python_version < "3.0"'
+        'regex',
+        'six',
+        'typing; python_version < "3.0"',
+    ],
 
     extras_require = {
         'django':['filters-django'],


### PR DESCRIPTION
# Filters v1.3.1
**⚠️ This version requires pip 9 or later to install.  If you encounter errors when upgrading, please run `pip install --upgrade pip` ⚠️**

- Fixed minor issues with Travis CI configuration.
- Travis CI now deploys universal wheels during production builds.